### PR TITLE
Add OAuth helper and firmware sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ After linking, you can disable/remove the extension.
 
 > Note: You can add multiple Indego devices individually.
 
+### Alternative OAuth Helper
+
+If you prefer not to use Chrome, run `auth_proxy.py` from this repository. It
+starts a small web server that forwards the OAuth callback to Home Assistant.
+Open the printed URL, complete the login and the token will be sent to HA.
+
 ---
 
 ## 🪡 Entities & Sensors

--- a/auth_proxy.py
+++ b/auth_proxy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""OAuth redirect helper for Bosch Indego integration.
+
+This small web server captures the OAuth callback from Bosch SingleKey ID and
+forwards it to Home Assistant. Run this script and open the printed URL in your
+browser to authenticate without the Chrome extension.
+"""
+import http.server
+import socketserver
+import urllib.parse
+import webbrowser
+
+PORT = 8765
+
+class OAuthHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        query = urllib.parse.urlparse(self.path).query
+        if "code=" in query:
+            ha_url = "https://my.home-assistant.io/redirect/oauth?" + query
+            self.send_response(302)
+            self.send_header("Location", ha_url)
+            self.end_headers()
+            print("Forwarding to Home Assistant:", ha_url)
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+
+
+def main():
+    url = (
+        "https://prodindego.b2clogin.com/prodindego.onmicrosoft.com/"
+        "b2c_1a_signup_signin/oauth2/v2.0/authorize?redirect_uri=http://localhost:%d"
+        % PORT
+    )
+    with socketserver.TCPServer(("localhost", PORT), OAuthHandler) as httpd:
+        print(f"Open the following URL in your browser:\n{url}")
+        webbrowser.open(url)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Stopping server")
+
+if __name__ == "__main__":
+    main()

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -213,6 +213,14 @@ ENTITY_DEFINITIONS = {
         CONF_UNIT_OF_MEASUREMENT: "m²",
         CONF_ATTR: [],
     },
+    ENTITY_FIRMWARE: {
+        CONF_TYPE: SENSOR_TYPE,
+        CONF_NAME: "firmware version",
+        CONF_ICON: "mdi:chip",
+        CONF_DEVICE_CLASS: None,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ATTR: [],
+    },
     ENTITY_CAMERA: {
         CONF_TYPE: CAMERA_TYPE,
     },
@@ -719,7 +727,7 @@ class IndegoHub:
             _LOGGER.warning("Timeout on update_state() – Mower not available or too slow")
             return
         except Exception as e:
-            _LOGGER.exception("Fehler on update_state() – actual mower_state=%s", self._last_state)
+            _LOGGER.exception("Error on update_state() – actual mower_state=%s", self._last_state)
             return
 
         state = self._indego_client.state
@@ -855,6 +863,11 @@ class IndegoHub:
                 self.entities[
                     ENTITY_MOWING_MODE
                 ].state = self._indego_client.generic_data.mowing_mode_description
+
+            if ENTITY_FIRMWARE in self.entities:
+                self.entities[ENTITY_FIRMWARE].state = (
+                    self._indego_client.generic_data.alm_firmware_version
+                )
 
         return self._indego_client.generic_data
 

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -42,7 +42,6 @@ SENSOR_TYPE: Final = "sensor"
 BINARY_SENSOR_TYPE: Final = "binary_sensor"
 VACUUM_TYPE: Final = "vacuum"
 LAWN_MOWER_TYPE: Final = "lawn_mower"
-CAMERA_TYPE: Final = "camera"
 INDEGO_PLATFORMS: Final = [SENSOR_TYPE, BINARY_SENSOR_TYPE, VACUUM_TYPE, LAWN_MOWER_TYPE, CAMERA_TYPE]
 
 ENTITY_ONLINE: Final = "online"
@@ -59,6 +58,7 @@ ENTITY_RUNTIME: Final = "runtime_total"
 ENTITY_VACUUM: Final = "vacuum"
 ENTITY_LAWN_MOWER: Final = "lawn_mower"
 ENTITY_GARDEN_SIZE: Final = "garden_size"
+ENTITY_FIRMWARE: Final = "firmware_version"
 ENTITY_CAMERA: Final = "camera"
 
 HTTP_HEADER_USER_AGENT: Final = "User-Agent"

--- a/info.md
+++ b/info.md
@@ -6,7 +6,7 @@
 
 # Bosch Indego Mower – Lovelace Enhanced Edition
 
-![Screenshot](https://raw.githubusercontent.com/dein-github-user/dein-repo-name/main/doc/0-Sensors_3.png)
+![Screenshot](https://raw.githubusercontent.com/WhyLev/indegohomeassistant/main/doc/0-Sensors_3.png)
 
 This is a custom fork of the original [Indego integration](https://github.com/sander1988/Indego) for Home Assistant – enhanced with:
 
@@ -22,6 +22,7 @@ This is a custom fork of the original [Indego integration](https://github.com/sa
 ### 🧹 Installation
 
 > Don’t forget to install the Chrome extension (see [README](https://github.com/WhyLev/indegohomeassistant/blob/main/README.md)) to finish the login process.
+> Alternatively, run `auth_proxy.py` to handle the OAuth callback without Chrome.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `firmware_version` sensor based on generic mower data
- include new `auth_proxy.py` helper for OAuth without Chrome
- document the helper in README and info

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e8b0dc0e4833181b1c81050970bf4