### PR TITLE
Add Indego forecast sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * Alert and error handling with delete/read actions
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling
+* Forecast sensor with rain probability & mow suggestion
 * Mushroom-based Lovelace dashboard with
 
   * Status grid
@@ -79,6 +80,7 @@ All entities are auto-discovered and appear under *unused entities* after integr
 | Alerts present     | `binary_sensor.indego_alert`            |
 | Last completed     | `sensor.indego_last_completed`          |
 | Next scheduled mow | `sensor.indego_next_mow`                |
+| Forecast           | `sensor.indego_forecast`                |
 | Mowing mode        | `sensor.indego_mowing_mode`             |
 | Garden size        | `sensor.indego_garden_size`             |
 | Online state       | `binary_sensor.indego_online`           |
@@ -86,6 +88,8 @@ All entities are auto-discovered and appear under *unused entities* after integr
 | Firmware version   | `sensor.indego_firmware_version`        |
 | Serial number      | `sensor.indego_serial_number`           |
 | Camera map         | `camera.indego`                         |
+
+`sensor.indego_forecast` exposes rain probability and the next recommended mowing time based on Indego's predictive schedule.
 
 ---
 

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -179,6 +179,14 @@ ENTITY_DEFINITIONS = {
         CONF_UNIT_OF_MEASUREMENT: None,
         CONF_ATTR: [],
     },
+    ENTITY_FORECAST: {
+        CONF_TYPE: SENSOR_TYPE,
+        CONF_NAME: "forecast",
+        CONF_ICON: "mdi:weather-partly-cloudy",
+        CONF_DEVICE_CLASS: None,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ATTR: ["rain_probability", "recommended_next_mow"],
+    },
     ENTITY_MOWING_MODE: {
         CONF_TYPE: SENSOR_TYPE,
         CONF_NAME: "mowing mode",
@@ -687,6 +695,7 @@ class IndegoHub:
                 self._update_alerts(),
                 self._update_last_completed_mow(),
                 self._update_next_mow(),
+                self._update_forecast(),
             ],
             return_exceptions=True,
         )
@@ -961,6 +970,20 @@ class IndegoHub:
 
             self.entities[ENTITY_LAWN_MOWED].add_attributes(
                 {"next_mow": next_mow}
+            )
+
+    async def _update_forecast(self):
+        await self._indego_client.update_predictive_calendar()
+
+        if self._indego_client.predictive_calendar:
+            forecast = self._indego_client.predictive_calendar[0]
+            self.entities[ENTITY_FORECAST].state = forecast.get("recommendation")
+
+            self.entities[ENTITY_FORECAST].set_attributes(
+                {
+                    "rain_probability": forecast.get("rainChance"),
+                    "recommended_next_mow": forecast.get("nextStart"),
+                }
             )
 
     @property

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -64,6 +64,7 @@ ENTITY_GARDEN_SIZE: Final = "garden_size"
 ENTITY_FIRMWARE: Final = "firmware_version"
 ENTITY_SERIAL_NUMBER: Final = "serial_number"
 ENTITY_CAMERA: Final = "camera"
+ENTITY_FORECAST: Final = "forecast"
 
 HTTP_HEADER_USER_AGENT: Final = "User-Agent"
 HTTP_HEADER_USER_AGENT_DEFAULT: Final = "HA/Indego"

--- a/info.md
+++ b/info.md
@@ -13,7 +13,7 @@ This is a custom fork of the original [Indego integration](https://github.com/sa
 * 🔑 Modern OAuth login
 * 🧱 Live map camera (as a `generic camera` entity) (based on [kimzeuner](https://github.com/kimzeuner)'s contributions)
 * 🎨 Beautiful Lovelace Dashboard example (Mushroom Cards)
-* 🌦️ Weather, UV & Rain forecast support
+* 🌦️ Weather, UV & Rain forecast support (via `sensor.indego_forecast`)
 * ✅ Full YAML compatibility
 * 🛠️ Optimized UX and simplified setup
 


### PR DESCRIPTION
## Summary
- add `ENTITY_FORECAST` constant
- create forecast sensor in hub and update periodic refresh
- document the new sensor and its attributes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea3eeea20833187368c1a06d8cce1