### PR TITLE
Add progress overlay to Indego camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 
 * OAuth2 login via Bosch SingleKey ID
 * Real-time state, mowing progress, battery status
-* Camera map view (rendered map)
+* Camera map view with animated mowing progress (resets after 24h or on completion)
 * Alert and error handling with delete/read actions
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling
@@ -87,7 +87,7 @@ All entities are auto-discovered and appear under *unused entities* after integr
 | Update available   | `binary_sensor.indego_update_available` |
 | Firmware version   | `sensor.indego_firmware_version`        |
 | Serial number      | `sensor.indego_serial_number`           |
-| Camera map         | `camera.indego`                         |
+| Camera map         | `camera.indego` (shows progress)        |
 
 ---
 


### PR DESCRIPTION
## Summary
- animate mower movement by keeping history of positions in `IndegoCamera`
- automatically reset the overlay after 24h or when mowing reaches 100%
- document the new behaviour in README

## Testing
- `python -m compileall -q custom_components/indego`

------
https://chatgpt.com/codex/tasks/task_e_685ea2a4ca1c83318eb5709ecb4d249e