### PR TITLE
Add progress line width constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * OAuth2 login via Bosch SingleKey ID
 * Real-time state, mowing progress, battery status
 * Static map camera plus animated progress camera (resets after 24h or on completion)
+* Progress path line width set by `MAP_PROGRESS_LINE_WIDTH` (default 6px)
 * Alert and error handling with delete/read actions
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling

--- a/custom_components/indego/camera.py
+++ b/custom_components/indego/camera.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, MAP_PROGRESS_LINE_WIDTH
 from .mixins import IndegoEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class IndegoCamera(IndegoEntity, Camera):
                     last_x, last_y = self._positions[-1]
                     self._path_svg += (
                         f'<line x1="{last_x}" y1="{last_y}" x2="{xpos}" y2="{ypos}" '
-                        f'stroke="#808080" stroke-width="4" stroke-linecap="round" />'
+                        f'stroke="#808080" stroke-width="{MAP_PROGRESS_LINE_WIDTH}" stroke-linecap="round" />'
                     )
                 self._positions.append((xpos, ypos))
 

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -78,3 +78,6 @@ HTTP_HEADER_USER_AGENT_DEFAULTS: Final = [
     "HomeAssistant/Indego",
     "HA/Indego"
 ]
+
+# Width of progress lines drawn on the map camera (in pixels)
+MAP_PROGRESS_LINE_WIDTH: Final = 6


### PR DESCRIPTION
## Summary
- add `MAP_PROGRESS_LINE_WIDTH` constant
- use `MAP_PROGRESS_LINE_WIDTH` in progress path lines
- document the new constant in README

## Testing
- `python -m py_compile custom_components/indego/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685ebd9561088331b3ded6e87d857c5d