### PR TITLE
Update default position update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * Alert and error handling with delete/read actions
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling
+* Map position updates every 10 seconds by default (configurable)
 * Forecast sensor with rain probability & mow suggestion
 * Mushroom-based Lovelace dashboard with
 

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -26,7 +26,7 @@ CONF_SMARTMOWING: Final = "enable"
 CONF_POLLING: Final = "polling"
 CONF_POSITION_UPDATE_INTERVAL: Final = "position_update_interval"
 
-DEFAULT_POSITION_UPDATE_INTERVAL: Final = 15
+DEFAULT_POSITION_UPDATE_INTERVAL: Final = 10
 
 DEFAULT_NAME: Final = "Indego"
 DEFAULT_NAME_COMMANDS: Final = None


### PR DESCRIPTION
## Summary
- decrease `DEFAULT_POSITION_UPDATE_INTERVAL` from 15 to 10 seconds
- document the new default in README

## Testing
- `python -m py_compile custom_components/indego/const.py custom_components/indego/config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_685ebd96a55883318ff3554c0fb22524