### PR TITLE
Fix missing map after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling
 * Map position updates every 10 seconds by default (configurable)
+* Map file is automatically downloaded on Home Assistant restart if missing
 * Forecast sensor with rain probability & mow suggestion
 * Mushroom-based Lovelace dashboard with
 

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 import aiofiles
+import os
 from datetime import datetime, timedelta
 from aiohttp.client_exceptions import ClientResponseError
 
@@ -683,6 +684,10 @@ class IndegoHub:
         try:
             _LOGGER.debug("Refreshing initial operating data.")
             await self._update_operating_data()
+
+            if not os.path.exists(self.map_path()):
+                _LOGGER.debug("Map file missing, downloading")
+                await self.download_and_store_map()
 
         except Exception as exc:
             _LOGGER.warning("Error %s for while performing initial update", str(exc))

--- a/info.md
+++ b/info.md
@@ -16,6 +16,7 @@ This is a custom fork of the original [Indego integration](https://github.com/sa
 * 🌦️ Weather, UV & Rain forecast support (via `sensor.indego_forecast`)
 * ✅ Full YAML compatibility
 * 🛠️ Optimized UX and simplified setup
+* 📥 Map automatically downloaded on restart when missing
 
 ---
 


### PR DESCRIPTION
## Summary
- download mower map automatically on Home Assistant startup if SVG is missing
- document auto-download feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fca0348a4833195e9b7c2b56bc27d