### PR TITLE
Improve initial update logging

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -684,13 +684,15 @@ class IndegoHub:
         try:
             _LOGGER.debug("Refreshing initial operating data.")
             await self._update_operating_data()
+        except Exception:
+            _LOGGER.exception("Initial call to _update_operating_data failed")
 
+        try:
             if not os.path.exists(self.map_path()):
                 _LOGGER.debug("Map file missing, downloading")
                 await self.download_and_store_map()
-
-        except Exception as exc:
-            _LOGGER.warning("Error %s for while performing initial update", str(exc))
+        except Exception:
+            _LOGGER.exception("Initial map download failed")
 
     async def async_shutdown(self, _=None):
         """Remove all future updates, cancel tasks and close the client."""


### PR DESCRIPTION
## Summary
- update `_initial_update()` to give more specific `_LOGGER.exception` messages for setup failures

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fcdacdfa48331a7d4dd04b6e54a2d