### PR TITLE
Add configurable state update timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling
 * Map position updates every 10 seconds by default (configurable)
+* State update timeout configurable via `state_update_timeout` option (default 10s)
 * Map file is automatically downloaded on Home Assistant restart if missing
 * Forecast sensor with rain probability & mow suggestion
 * Mushroom-based Lovelace dashboard with

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -339,7 +339,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         entry.options.get(CONF_USER_AGENT),
         entry.options.get(CONF_POSITION_UPDATE_INTERVAL, DEFAULT_POSITION_UPDATE_INTERVAL),
-        entry.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES)
+        entry.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES),
+        entry.options.get(CONF_STATE_UPDATE_TIMEOUT, DEFAULT_STATE_UPDATE_TIMEOUT)
     )
 
     await indego_hub.start_periodic_position_update()
@@ -526,6 +527,7 @@ class IndegoHub:
         user_agent: Optional[str] = None,
         position_interval: int = DEFAULT_POSITION_UPDATE_INTERVAL,
         adaptive_updates: bool = DEFAULT_ADAPTIVE_POSITION_UPDATES,
+        state_update_timeout: int = DEFAULT_STATE_UPDATE_TIMEOUT,
     ):
         """Initialize the IndegoHub.
 
@@ -555,6 +557,7 @@ class IndegoHub:
         self._position_interval = position_interval
         self._current_position_interval = position_interval
         self._adaptive_updates = adaptive_updates
+        self._state_update_timeout = state_update_timeout
         self._weekly_area_entries = []
         self._last_completed_ts = None
 
@@ -850,7 +853,7 @@ class IndegoHub:
 
     async def _check_position_and_state(self, now):
         try:
-            await self._indego_client.update_state(force=True)
+            await self._indego_client.update_state(force=True, timeout=self._state_update_timeout)
         except asyncio.TimeoutError:
             _LOGGER.warning("Timeout on update_state() – Mower not available or too slow")
             return

--- a/custom_components/indego/config_flow.py
+++ b/custom_components/indego/config_flow.py
@@ -24,8 +24,10 @@ from .const import (
     CONF_USER_AGENT,
     CONF_POSITION_UPDATE_INTERVAL,
     CONF_ADAPTIVE_POSITION_UPDATES,
+    CONF_STATE_UPDATE_TIMEOUT,
     DEFAULT_POSITION_UPDATE_INTERVAL,
     DEFAULT_ADAPTIVE_POSITION_UPDATES,
+    DEFAULT_STATE_UPDATE_TIMEOUT,
     OAUTH2_CLIENT_ID,
     HTTP_HEADER_USER_AGENT,
     HTTP_HEADER_USER_AGENT_DEFAULT,
@@ -91,6 +93,10 @@ class IndegoOptionsFlowHandler(OptionsFlowWithConfigEntry):
                     CONF_ADAPTIVE_POSITION_UPDATES,
                     default=self.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES),
                 ): bool,
+                vol.Optional(
+                    CONF_STATE_UPDATE_TIMEOUT,
+                    default=self.options.get(CONF_STATE_UPDATE_TIMEOUT, DEFAULT_STATE_UPDATE_TIMEOUT),
+                ): int,
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)
@@ -182,6 +188,7 @@ class IndegoFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
             self._options[CONF_EXPOSE_INDEGO_AS_VACUUM] = user_input[CONF_EXPOSE_INDEGO_AS_VACUUM]
             self._options[CONF_POSITION_UPDATE_INTERVAL] = user_input[CONF_POSITION_UPDATE_INTERVAL]
             self._options[CONF_ADAPTIVE_POSITION_UPDATES] = user_input[CONF_ADAPTIVE_POSITION_UPDATES]
+            self._options[CONF_STATE_UPDATE_TIMEOUT] = user_input[CONF_STATE_UPDATE_TIMEOUT]
 
             try:
                 self._mower_serials = await api_client.get_mowers()
@@ -234,6 +241,10 @@ class IndegoFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                     CONF_ADAPTIVE_POSITION_UPDATES,
                     default=(self._options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES))
                 ): bool,
+                vol.Optional(
+                    CONF_STATE_UPDATE_TIMEOUT,
+                    default=(self._options.get(CONF_STATE_UPDATE_TIMEOUT, DEFAULT_STATE_UPDATE_TIMEOUT))
+                ): int,
             }
         )
         return self.async_show_form(step_id="advanced", data_schema=schema)

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -26,9 +26,11 @@ CONF_SMARTMOWING: Final = "enable"
 CONF_POLLING: Final = "polling"
 CONF_POSITION_UPDATE_INTERVAL: Final = "position_update_interval"
 CONF_ADAPTIVE_POSITION_UPDATES: Final = "adaptive_position_updates"
+CONF_STATE_UPDATE_TIMEOUT: Final = "state_update_timeout"
 
 DEFAULT_POSITION_UPDATE_INTERVAL: Final = 10
 DEFAULT_ADAPTIVE_POSITION_UPDATES: Final = True
+DEFAULT_STATE_UPDATE_TIMEOUT: Final = 10
 
 DEFAULT_NAME: Final = "Indego"
 DEFAULT_NAME_COMMANDS: Final = None


### PR DESCRIPTION
## Summary
- add `state_update_timeout` constants
- expose option in config flow
- pass timeout to Indego hub and client
- document option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fcdaf411c83319ed49ea7fb06f41a