### PR TITLE
Add customizable map progress options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This fork combines the solid Bosch Indego integration developed by [sander1988](
 * OAuth2 login via Bosch SingleKey ID
 * Real-time state, mowing progress, battery status
 * Static map camera plus animated progress camera (resets after 24h or on completion)
-* Progress path line width set by `MAP_PROGRESS_LINE_WIDTH` (default 6px)
+* Progress path appearance configurable (width & color)
 * Alert and error handling with delete/read actions
 * Service commands: mow, pause, return to dock
 * SmartMowing toggling

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -339,7 +339,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         entry.options.get(CONF_USER_AGENT),
         entry.options.get(CONF_POSITION_UPDATE_INTERVAL, DEFAULT_POSITION_UPDATE_INTERVAL),
-        entry.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES)
+        entry.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES),
+        entry.options.get(CONF_PROGRESS_LINE_WIDTH, MAP_PROGRESS_LINE_WIDTH),
+        entry.options.get(CONF_PROGRESS_LINE_COLOR, MAP_PROGRESS_LINE_COLOR),
     )
 
     await indego_hub.start_periodic_position_update()
@@ -526,6 +528,8 @@ class IndegoHub:
         user_agent: Optional[str] = None,
         position_interval: int = DEFAULT_POSITION_UPDATE_INTERVAL,
         adaptive_updates: bool = DEFAULT_ADAPTIVE_POSITION_UPDATES,
+        progress_line_width: int = MAP_PROGRESS_LINE_WIDTH,
+        progress_line_color: str = MAP_PROGRESS_LINE_COLOR,
     ):
         """Initialize the IndegoHub.
 
@@ -555,6 +559,8 @@ class IndegoHub:
         self._position_interval = position_interval
         self._current_position_interval = position_interval
         self._adaptive_updates = adaptive_updates
+        self._progress_line_width = progress_line_width
+        self._progress_line_color = progress_line_color
         self._weekly_area_entries = []
         self._last_completed_ts = None
 
@@ -1153,3 +1159,11 @@ class IndegoHub:
     @property
     def client(self) -> IndegoAsyncClient:
         return self._indego_client
+
+    @property
+    def progress_line_width(self) -> int:
+        return self._progress_line_width
+
+    @property
+    def progress_line_color(self) -> str:
+        return self._progress_line_color

--- a/custom_components/indego/camera.py
+++ b/custom_components/indego/camera.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, MAP_PROGRESS_LINE_WIDTH
+from .const import DOMAIN
 from .mixins import IndegoEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class IndegoCamera(IndegoEntity, Camera):
                     last_x, last_y = self._positions[-1]
                     self._path_svg += (
                         f'<line x1="{last_x}" y1="{last_y}" x2="{xpos}" y2="{ypos}" '
-                        f'stroke="#808080" stroke-width="{MAP_PROGRESS_LINE_WIDTH}" stroke-linecap="round" />'
+                        f'stroke="{self._indego_hub.progress_line_color}" stroke-width="{self._indego_hub.progress_line_width}" stroke-linecap="round" />'
                     )
                 self._positions.append((xpos, ypos))
 

--- a/custom_components/indego/config_flow.py
+++ b/custom_components/indego/config_flow.py
@@ -24,8 +24,12 @@ from .const import (
     CONF_USER_AGENT,
     CONF_POSITION_UPDATE_INTERVAL,
     CONF_ADAPTIVE_POSITION_UPDATES,
+    CONF_PROGRESS_LINE_WIDTH,
+    CONF_PROGRESS_LINE_COLOR,
     DEFAULT_POSITION_UPDATE_INTERVAL,
     DEFAULT_ADAPTIVE_POSITION_UPDATES,
+    MAP_PROGRESS_LINE_WIDTH,
+    MAP_PROGRESS_LINE_COLOR,
     OAUTH2_CLIENT_ID,
     HTTP_HEADER_USER_AGENT,
     HTTP_HEADER_USER_AGENT_DEFAULT,
@@ -91,6 +95,14 @@ class IndegoOptionsFlowHandler(OptionsFlowWithConfigEntry):
                     CONF_ADAPTIVE_POSITION_UPDATES,
                     default=self.options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES),
                 ): bool,
+                vol.Optional(
+                    CONF_PROGRESS_LINE_WIDTH,
+                    default=self.options.get(CONF_PROGRESS_LINE_WIDTH, MAP_PROGRESS_LINE_WIDTH),
+                ): int,
+                vol.Optional(
+                    CONF_PROGRESS_LINE_COLOR,
+                    default=self.options.get(CONF_PROGRESS_LINE_COLOR, MAP_PROGRESS_LINE_COLOR),
+                ): str,
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)
@@ -182,6 +194,8 @@ class IndegoFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
             self._options[CONF_EXPOSE_INDEGO_AS_VACUUM] = user_input[CONF_EXPOSE_INDEGO_AS_VACUUM]
             self._options[CONF_POSITION_UPDATE_INTERVAL] = user_input[CONF_POSITION_UPDATE_INTERVAL]
             self._options[CONF_ADAPTIVE_POSITION_UPDATES] = user_input[CONF_ADAPTIVE_POSITION_UPDATES]
+            self._options[CONF_PROGRESS_LINE_WIDTH] = user_input[CONF_PROGRESS_LINE_WIDTH]
+            self._options[CONF_PROGRESS_LINE_COLOR] = user_input[CONF_PROGRESS_LINE_COLOR]
 
             try:
                 self._mower_serials = await api_client.get_mowers()
@@ -234,6 +248,14 @@ class IndegoFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                     CONF_ADAPTIVE_POSITION_UPDATES,
                     default=(self._options.get(CONF_ADAPTIVE_POSITION_UPDATES, DEFAULT_ADAPTIVE_POSITION_UPDATES))
                 ): bool,
+                vol.Optional(
+                    CONF_PROGRESS_LINE_WIDTH,
+                    default=(self._options.get(CONF_PROGRESS_LINE_WIDTH, MAP_PROGRESS_LINE_WIDTH))
+                ): int,
+                vol.Optional(
+                    CONF_PROGRESS_LINE_COLOR,
+                    default=(self._options.get(CONF_PROGRESS_LINE_COLOR, MAP_PROGRESS_LINE_COLOR))
+                ): str,
             }
         )
         return self.async_show_form(step_id="advanced", data_schema=schema)

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -86,3 +86,9 @@ HTTP_HEADER_USER_AGENT_DEFAULTS: Final = [
 
 # Width of progress lines drawn on the map camera (in pixels)
 MAP_PROGRESS_LINE_WIDTH: Final = 6
+# Default color of progress lines drawn on the map camera
+MAP_PROGRESS_LINE_COLOR: Final = "#808080"
+
+# Configuration options for map progress path appearance
+CONF_PROGRESS_LINE_WIDTH: Final = "progress_line_width"
+CONF_PROGRESS_LINE_COLOR: Final = "progress_line_color"

--- a/custom_components/indego/manifest.json
+++ b/custom_components/indego/manifest.json
@@ -7,6 +7,6 @@
   "codeowners": ["@WhyLev"],
   "requirements": ["pyIndego==3.2.2", "svgutils==0.3.4"],
   "iot_class": "cloud_push",
-  "version": "1.1",
+  "version": "1.2",
   "loggers": ["custom_components.indego", "pyIndego"]
 }

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -14,6 +14,8 @@
                     "expose_vacuum": "Indego Mähroboter als Vacuum Entität in HomeAssistant anlegen",
                     "position_update_interval": "Positionsaktualisierungsintervall (Sekunden)",
                     "adaptive_position_updates": "Abfrage verringern, wenn Mäher angedockt"
+        , "progress_line_width": "Progress line width (px)"
+        , "progress_line_color": "Progress line color"
                 },
                 "description": "Erweiterte Einstellung des Bosch Indego Component."
             },
@@ -42,6 +44,8 @@
                     "show_all_alerts": "Zeige den kompletten Alarm Verlauf in HomeAssistant. Dies wird für die meisten Nutzer nicht empfohlen, da es signifikanten Einfluss auf die Größe der HomeAssistant Datenbank haben kann.",
                     "position_update_interval": "Positionsaktualisierungsintervall (Sekunden)",
                     "adaptive_position_updates": "Abfrage verringern, wenn Mäher angedockt"
+        , "progress_line_width": "Progress line width (px)"
+        , "progress_line_color": "Progress line color"
                 }
             }
         }

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -13,7 +13,9 @@
                     "expose_mower": "Expose Indego mower as mower entity in HomeAssistant",
                     "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant",
                     "position_update_interval": "Position update interval (seconds)",
-                    "adaptive_position_updates": "Reduce polling when mower is docked"
+                    "adaptive_position_updates": "Reduce polling when mower is docked",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 },
                 "description": "Advanced settings of the Bosch Indego component."
             },
@@ -41,7 +43,9 @@
                   "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant",
                     "show_all_alerts": "Show the full alert history into HomeAssistant. This is not recommended for most users, it might have a significant impact on the HomeAssistant database size!",
                     "position_update_interval": "Position update interval (seconds)",
-                    "adaptive_position_updates": "Reduce polling when mower is docked"
+                    "adaptive_position_updates": "Reduce polling when mower is docked",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 }
           }
       }

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -14,6 +14,8 @@
                     "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant",
                     "position_update_interval": "Position update interval (seconds)",
                     "adaptive_position_updates": "Reduce polling when mower is docked"
+        , "progress_line_width": "Progress line width (px)"
+        , "progress_line_color": "Progress line color"
                 },
                 "description": "Advanced settings of the Bosch Indego component."
             },
@@ -42,6 +44,8 @@
                     "show_all_alerts": "Show the full alert history into HomeAssistant. This is not recommended for most users, it might have a significant impact on the HomeAssistant database size!",
                     "position_update_interval": "Position update interval (seconds)",
                     "adaptive_position_updates": "Reduce polling when mower is docked"
+        , "progress_line_width": "Progress line width (px)"
+        , "progress_line_color": "Progress line color"
                 }
           }
       }

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -11,7 +11,9 @@
                 "data": {
                     "user_agent": "User-Agent",
                     "expose_mower": "Exposer la tondeuse Indego comme une entité tondeuse dans HomeAssistant",
-                    "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant"
+                    "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 },
                 "description": "Réglages avancés du composant Bosch Indego. Peuvent être laissés inchangés pour la plupart des utilisateurs."
             },
@@ -37,8 +39,10 @@
                   "user_agent": "User-Agent",
                   "expose_mower": "Exposer la tondeuse Indego comme une entité tondeuse dans HomeAssistant",
                   "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant",
-                  "show_all_alerts": "Montrer l'historique complet des alertes dans HomeAssistant. Non recommandé pour la plupart des utilisateurs, l'impact sur la taille de la base de données HomeAssistant peut être assez important!"
-              }
+                    "show_all_alerts": "Montrer l'historique complet des alertes dans HomeAssistant. Non recommandé pour la plupart des utilisateurs, l'impact sur la taille de la base de données HomeAssistant peut être assez important!",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
+                }
           }
       }
     },

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -11,7 +11,9 @@
                 "data": {
                     "user_agent": "User-Agent",
                     "expose_mower": "Voeg de Indego robotmaaier toe als grasmaaier entiteit aan HomeAssistant",
-                    "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant"
+                    "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 },
                 "description": "Geavanceerde instellingen van het Bosch Indego component."
             },
@@ -37,7 +39,9 @@
                   "user_agent": "User-Agent",
                   "expose_mower": "Voeg de Indego robotmaaier toe als grasmaaier entiteit aan HomeAssistant",
                   "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant",
-                  "show_all_alerts": "Toon de volledige melding/waarschuwing geschiedenis in HomeAssistant. Dit wordt niet aangeraden voor de meeste gebruikers, het heeft mogelijk een significante impact op de HomeAssistant database!"
+                  "show_all_alerts": "Toon de volledige melding/waarschuwing geschiedenis in HomeAssistant. Dit wordt niet aangeraden voor de meeste gebruikers, het heeft mogelijk een significante impact op de HomeAssistant database!",
+                  "progress_line_width": "Progress line width (px)",
+                  "progress_line_color": "Progress line color"
               }
           }
       }

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -10,7 +10,9 @@
                 "data": {
                     "user_agent": "User-Agent",
                     "expose_mower": "Wyświetl kosiarkę Indego jako encję kosiarki w HomeAssistant",
-                    "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant"
+                    "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 },
                 "description": "Ustawienia zaawansowane komponentu Bosch Indego."
             },
@@ -32,7 +34,9 @@
                   "user_agent": "User-Agent",
                   "expose_mower": "Wyświetl kosiarkę Indego jako encję kosiarki w HomeAssistant",
                   "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant",
-                  "show_all_alerts": "Pokaż pełną historię alertów w HomeAssistant. Nie rekomendowane dla większości użytkowników, może mieć wpływ na znaczące zwiększenie rozmiaru bazy danych HomeAssistant!"
+                  "show_all_alerts": "Pokaż pełną historię alertów w HomeAssistant. Nie rekomendowane dla większości użytkowników, może mieć wpływ na znaczące zwiększenie rozmiaru bazy danych HomeAssistant!",
+                  "progress_line_width": "Progress line width (px)",
+                  "progress_line_color": "Progress line color"
               }
           }
       }

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -10,7 +10,9 @@
                 "data": {
                     "user_agent": "User-Agent",
                     "expose_mower": "Odhaľte kosačku Indego ako entitu kosačky v aplikácii HomeAssistant",
-                    "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant"
+                    "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant",
+                    "progress_line_width": "Progress line width (px)",
+                    "progress_line_color": "Progress line color"
                 },
                 "description": "Rozšírené nastavenia komponentu Bosch Indego."
             },
@@ -32,7 +34,9 @@
                   "user_agent": "User-Agent",
                   "expose_mower": "Odhaľte kosačku Indego ako entitu kosačky v aplikácii HomeAssistant",
                   "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant",
-                  "show_all_alerts": "Zobrazte celú históriu upozornení v aplikácii HomeAssistant. Toto sa neodporúča väčšine používateľov, môže to mať významný vplyv na veľkosť databázy HomeAssistant!"
+                  "show_all_alerts": "Zobrazte celú históriu upozornení v aplikácii HomeAssistant. Toto sa neodporúča väčšine používateľov, môže to mať významný vplyv na veľkosť databázy HomeAssistant!",
+                  "progress_line_width": "Progress line width (px)",
+                  "progress_line_color": "Progress line color"
               }
           }
       }


### PR DESCRIPTION
## Summary
- support custom progress line width and color
- include options in setup and options flow
- expose new settings to map camera
- document new features in README
- bump version to 1.2

## Testing
- `python -m compileall custom_components/indego`

------
https://chatgpt.com/codex/tasks/task_e_685fccd22b108331a94e793675f7fc0b