### PR TITLE
Improve map saving log & clarify path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ You can call the following services:
 | `indego.delete_alert_all` | Delete all alerts                      |
 | `indego.download_map`     | Save the mower map to `www/indego_map_SERIALNUMBER.svg` |
 
+The map file is saved inside Home Assistant's configuration directory. On
+standard installations this is accessible at `/config/www` from within the
+container. If you run Home Assistant in Docker, this folder maps to the path
+where your configuration volume is mounted (for example
+`volumes/homeassistant/config/www`).
+
 ---
 
 ## 📊 Dashboard

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -832,19 +832,19 @@ class IndegoHub:
 
     async def download_and_store_map(self):
         """Download the current map and store it as an SVG file."""
+        path = self.map_path()
         try:
             svg_bytes = await self._indego_client.download_map(self._serial)
-            if svg_bytes:
-                path = self._hass.config.path(
-                    "www", f"indego_map_{self._serial}.svg"
-                )
-                os.makedirs(os.path.dirname(path), exist_ok=True)
-                async with aiofiles.open(path, "wb") as f:
-                    await f.write(svg_bytes)
-                _LOGGER.info("Map saved in %s", path)
+            if not svg_bytes:
+                _LOGGER.warning("Map download for %s returned no data", self._serial)
+                return
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            async with aiofiles.open(path, "wb") as f:
+                await f.write(svg_bytes)
+            _LOGGER.info("Map saved in %s", path)
         except Exception as e:
             _LOGGER.warning(
-                "Error during saving the map [%s]: %s", self._serial, e
+                "Error during saving the map [%s] to %s: %s", self._serial, path, e
             )
 
     async def start_periodic_position_update(self, interval: int | None = None):


### PR DESCRIPTION
## Summary
- add detailed warnings when map download fails and include target path
- clarify where the map is stored in README

## Testing
- `python -m py_compile custom_components/indego/__init__.py`
- `python -m py_compile custom_components/indego/camera.py`


------
https://chatgpt.com/codex/tasks/task_e_685fe79bd4a48331bed41f31a356fc61