### PR TITLE
Fix manifest version duplication

### DIFF
--- a/custom_components/indego/manifest.json
+++ b/custom_components/indego/manifest.json
@@ -7,7 +7,6 @@
   "codeowners": ["@WhyLev"],
   "requirements": ["pyIndego==3.2.2", "svgutils==0.3.4"],
   "iot_class": "cloud_push",
-  "version": "1.2",
   "version": "1.2.1",
   "loggers": ["custom_components.indego", "pyIndego"]
 }


### PR DESCRIPTION
## Summary
- remove outdated `"version": "1.2"` from the Indego integration manifest

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68628392f6b8833186f183c5ddf2b586