### PR TITLE
Add rate limit handling

### DIFF
--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -89,6 +89,10 @@ HTTP_HEADER_USER_AGENT_DEFAULTS: Final = [
     "HA/Indego"
 ]
 
+# Default delay in seconds when the API returns HTTP 429 without a
+# ``Retry-After`` header.
+RETRY_AFTER_DEFAULT: Final = 60
+
 # Width of progress lines drawn on the map camera (in pixels)
 MAP_PROGRESS_LINE_WIDTH: Final = 6
 # Default color of progress lines drawn on the map camera


### PR DESCRIPTION
## Summary
- add retry-after constant
- detect HTTP 429 and skip polling when API rate limit is hit
- parse Retry-After header and set cooldown for further requests

## Testing
- `python -m py_compile custom_components/indego/__init__.py custom_components/indego/const.py`

------
https://chatgpt.com/codex/tasks/task_e_686423d034cc8331963720ecd864df78