### PR TITLE
Fix early entity update

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -651,7 +651,10 @@ class IndegoHub:
                 elif entity_key == ENTITY_API_ERRORS:
                     # Initialize API error counter with zero
                     self.entities[entity_key]._state = 0
-                    self.entities[entity_key].set_attributes({})
+                    # Avoid scheduling a state update before the entity is
+                    # added to Home Assistant. Attributes will be set once
+                    # the entity is registered, so disable sync here.
+                    self.entities[entity_key].set_attributes({}, sync_state=False)
 
             elif entity[CONF_TYPE] == BINARY_SENSOR_TYPE:
                 self.entities[entity_key] = IndegoBinarySensor(


### PR DESCRIPTION
## Summary
- avoid calling `async_schedule_update_ha_state` before the API errors sensor is registered

## Testing
- `ruff check custom_components/indego/__init__.py` *(fails: many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686428fc5c588331aa73a518ebce337c