### PR TITLE
Fix mower sensors flicker offline

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -825,7 +825,7 @@ class IndegoHub:
             self._unsub_refresh_state = async_track_point_in_time(self._hass, self._create_refresh_state_task, when)
             return
 
-        if self._indego_client.state:
+        if self._indego_client.state is not None:
             state = self._indego_client.state.state
             if (500 <= state <= 799) or (state in (257, 260)):
                 try:
@@ -1312,7 +1312,7 @@ class IndegoHub:
         if self._shutdown:
             return
 
-        if not self._indego_client.state:
+        if self._indego_client.state is None:
             self.set_online_state(False)
             return  # State update failed
 


### PR DESCRIPTION
## Summary
- avoid using falsy check for Indego state
- check explicitly for `None`

## Testing
- `python -m py_compile custom_components/indego/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68643a9e3ca88331bcdecab758e6fa21